### PR TITLE
add missing word "durchgesetzt"

### DIFF
--- a/gdi002_bits_de.tex
+++ b/gdi002_bits_de.tex
@@ -65,8 +65,8 @@ Das Dezimalsystem umfasst 10 verschiedene Ziffern.
 Fraglich ist, welche die erste natürliche Zahl ist. Einerseits wird mit $1$ zum
 Zählen begonnen und andererseits ist $0$ die Ziffer mit dem niedrigsten Wert.
 Jedenfalls hat es sich seit der C-Programmiersprache in der überwiegenden
-Mehrheit der Programmiersprachen \emph{Indexing} (das Referenzieren eines
-Eintrags in einer Sequenz) seit der mit Null beginnend durchzuführen
+Mehrheit der Programmiersprachen durchgesetzt \emph{Indexing} (das
+Referenzieren eines Eintrags in einer Sequenz) mit Null beginnend durchzuführen
 (,,null-basierte Nummerierung``).%
 \footnote{Ausnahmen (chronologisch betrachtet nach C) bilden etwa die Sprachen
 Lua, Mathematica, MATLAB und SQL}


### PR DESCRIPTION
alternatively something like: "Jedenfalls hat man begonnen seit der C-Programmiersprache in der überweigenden Mehrheit der Programmiersprachen Indexing (...) seit dem mit Null beginnend durchzuführen (...)."
