### PR TITLE
Add Barbara Liskov to list of famous computer scientists.

### DIFF
--- a/gdi013_people_de.tex
+++ b/gdi013_people_de.tex
@@ -18,6 +18,10 @@ Diese Liste erhebt keinerlei Anspruch auf Vollständigkeit und hebt nur Teile de
     Untersuchte und entwickelte jenen Logikkalkül, der Grundlage der modernen Logik heute ist.
     Ihm zu Ehren sprechen wir von boolschen Variablen und boolschen Formeln.
 
+  \item[Barbara Liskov \born{1939}] \hfill{} \\
+    Entwickelte zusammen mit Jeanette Wing das, für die objektorientierte Programmierung bedeutsame Liskovsche Substitutionsprinzip.
+    Weiters entwarf und entwickelte sie die Programmiersprchen CLU und Argus sowie das objektorientierte Datenbnkmangementsystems Thor.
+
   \item[Noam Chomsky \born{1928}] \hfill{} \\
     Amerikanischer Linguist, welcher durch Untersuchung der formalen Sprachen eine Klassifikation (,,Chomsky-Hierarchie``) der Sprachen nach ihrer Mächtigkeit erreichte.
     Trug damit erheblich zur Weiterentwicklung des Compilerbaus bei.

--- a/gdi013_people_en.tex
+++ b/gdi013_people_en.tex
@@ -8,6 +8,7 @@ List of computer scientists.
   \item John Backus
   \item Tim Berners-Lee
   \item George Boole
+  \item Barbara Liskov
   \item Noam Chomsky
   \item Edsger Dijkstra
   \item Grace Hopper


### PR DESCRIPTION
Durch ihren Fortschritt in der objektorientierten Programmierung und Programmiermethoddik hat sie viele, wenn nicht alle, Programmiersprachen beeinflusst. Deswegen wurde sie sowohl mit der John von Neumann Medaille, dem Turing Award und dem Computer Pioneer Award ausgezeichnet. Dadurch bin ich der Meinung das sie eine Platz in der Liste haben sollte.